### PR TITLE
use generic/ubuntu1804 rather than VB only jessie

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,7 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-     wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
+     wget --continue https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
      sudo dpkg -i erlang-solutions_1.0_all.deb
      sudo apt-get update
      sudo apt-get install -y esl-erlang=1:20.3.6

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,6 @@ Vagrant.configure("2") do |config|
      sudo dpkg -i erlang-solutions_1.0_all.deb
      sudo apt-get update
      sudo apt-get install -y esl-erlang=1:20.3.6
-     sudo apt-get install -y git
+     sudo apt-get install -y git make leiningen
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,5 +69,6 @@ Vagrant.configure("2") do |config|
      sudo apt-get update
      sudo apt-get install -y esl-erlang=1:20.3.6
      sudo apt-get install -y git make leiningen
+     sudo apt-get install -y openjdk-8-jre openjdk-8-jre-headless libjna-java
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "debian/contrib-jessie64"
+  config.vm.box = "generic/ubuntu1804"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
The debian/contrib-jessie64 is only available for virtualbox users,
generic/ubuntu1804 is equivalent and runs on 5 vagrant providers.