### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ See the [readme](jepsen/jepsen.rakvstore/README.md).
 
 # License
 
-RA KV Store is [Apache 2.0 licensed](http://www.apache.org/licenses/LICENSE-2.0.html).
+RA KV Store is [Apache 2.0 licensed](https://www.apache.org/licenses/LICENSE-2.0.html).
 
 _Sponsored by [Pivotal](http://pivotal.io)_

--- a/jepsen/jepsen.rakvstore/README.md
+++ b/jepsen/jepsen.rakvstore/README.md
@@ -188,6 +188,6 @@ changes can be checked by running Maven:
 
 ## License
 
-RA KV Store is [Apache 2.0 licensed](http://www.apache.org/licenses/LICENSE-2.0.html).
+RA KV Store is [Apache 2.0 licensed](https://www.apache.org/licenses/LICENSE-2.0.html).
 
 _Sponsored by [Pivotal](http://pivotal.io)_

--- a/jepsen/jepsen.rakvstore/project.clj
+++ b/jepsen/jepsen.rakvstore/project.clj
@@ -6,7 +6,7 @@
   :javac-options     ["-target" "1.8" "-source" "1.8"]
   :jvm-opts ["-Xmx3g"]
   :license {:name "Apache 2.0 License"
-            :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
+            :url "https://www.apache.org/licenses/LICENSE-2.0.html"}
   :main jepsen.rakvstore
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [jepsen "0.1.12"]])

--- a/jepsen/jepsen.rakvstore/src/clojure/jepsen/rakvstore.clj
+++ b/jepsen/jepsen.rakvstore/src/clojure/jepsen/rakvstore.clj
@@ -4,7 +4,7 @@
 ;; you may not use this file except in compliance with the License.
 ;; You may obtain a copy of the License at
 ;;
-;;       http://www.apache.org/licenses/LICENSE-2.0
+;;       https://www.apache.org/licenses/LICENSE-2.0
 ;;
 ;; Unless required by applicable law or agreed to in writing, software
 ;; distributed under the License is distributed on an "AS IS" BASIS,

--- a/jepsen/jepsen.rakvstore/src/clojure/jepsen/set.clj
+++ b/jepsen/jepsen.rakvstore/src/clojure/jepsen/set.clj
@@ -4,7 +4,7 @@
 ;; you may not use this file except in compliance with the License.
 ;; You may obtain a copy of the License at
 ;;
-;;       http://www.apache.org/licenses/LICENSE-2.0
+;;       https://www.apache.org/licenses/LICENSE-2.0
 ;;
 ;; Unless required by applicable law or agreed to in writing, software
 ;; distributed under the License is distributed on an "AS IS" BASIS,

--- a/jepsen/jepsen.rakvstore/src/java/com/rabbitmq/jepsen/Utils.java
+++ b/jepsen/jepsen.rakvstore/src/java/com/rabbitmq/jepsen/Utils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/jepsen/jepsen.rakvstore/test/java/com/rabbitmq/jepsen/UtilsTest.java
+++ b/jepsen/jepsen.rakvstore/test/java/com/rabbitmq/jepsen/UtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/ra_kv_store.erl
+++ b/src/ra_kv_store.erl
@@ -4,7 +4,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
-%%       http://www.apache.org/licenses/LICENSE-2.0
+%%       https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/ra_kv_store_app.erl
+++ b/src/ra_kv_store_app.erl
@@ -4,7 +4,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
-%%       http://www.apache.org/licenses/LICENSE-2.0
+%%       https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/ra_kv_store_handler.erl
+++ b/src/ra_kv_store_handler.erl
@@ -4,7 +4,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
-%%       http://www.apache.org/licenses/LICENSE-2.0
+%%       https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/ra_kv_store_sup.erl
+++ b/src/ra_kv_store_sup.erl
@@ -4,7 +4,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
-%%       http://www.apache.org/licenses/LICENSE-2.0
+%%       https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -4,7 +4,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
-%%       http://www.apache.org/licenses/LICENSE-2.0
+%%       https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/store_SUITE.erl
+++ b/test/store_SUITE.erl
@@ -4,7 +4,7 @@
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
-%%       http://www.apache.org/licenses/LICENSE-2.0
+%%       https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 11 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 3 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).